### PR TITLE
Fixed an issue with inability to run 'forCases' method for ArrangeActAssert

### DIFF
--- a/lib/nightwatch-data-driven.js
+++ b/lib/nightwatch-data-driven.js
@@ -39,12 +39,14 @@ var DataDrivenTest = (function () {
         if (!self.browser) {
             throw 'Browser not initialized';
         }
-        if (!self.arrange) {
-            throw 'Arrange not initialized';
-        }
-        if (!self.assert) {
-            throw 'Assert not initialized';
-        }
+        if (!self.aaa) {
+            if (!self.arrange) {
+                throw 'Arrange not initialized';
+            }
+            if (!self.assert) {
+                throw 'Assert not initialized';
+            }
+        }        
         for (var name_1 in cases) {
             if (cases.hasOwnProperty(name_1)) {
                 self.runCase(cases[name_1], name_1);


### PR DESCRIPTION
Fixed an issue with inability to run 'forCases' method without excessive setting of 'arrange' and 'assert' properties of DataDrivenTest when ArrangeActAssert function is already provided
